### PR TITLE
Remove unused index router

### DIFF
--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,7 +1,0 @@
-const express = require('express');
-const router = express.Router();
-
-router.use('/users', require('./usuarioRoutes.js'));
-// router.use('/equipos', require('./equipoRoutes')); // ejemplo
-
-module.exports = router;


### PR DESCRIPTION
## Summary
- delete `backend/src/routes/index.js` because it was unused

## Testing
- `npm test` in `backend` *(fails: no tests specified)*
- `npm run lint` in `frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d76381a5c83278d53902d46cacd49